### PR TITLE
Update version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ such as `Torchx` or `EXLA`, you need to explicitly depend on them.
 All of `NxSignal`'s functionality is provided through `Nx.Defn`, so things should work out of the
 box with different backends and compilers.
 
+## Guides (Livebook)
+
+Check out the "guides" folder in the repo for examples. 
+
 ## Contributing
 
 Contributions are more than welcome!

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to your Mix project:
 ```elixir
 def deps do
   [
-    {:nx_signal, "~> 0.5"}
+    {:nx_signal, "~> 0.1"}
   ]
 end
 ```
@@ -26,7 +26,7 @@ You can also use `Mix.install` for standalone development:
 
 ```elixir
 Mix.install([
-  {:nx_signal, "~> 0.5"}
+  {:nx_signal, "~> 0.1"}
 ])
 ```
 

--- a/guides/filtering.livemd
+++ b/guides/filtering.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:nx_signal, "~> 0.5", github: "elixir-nx/nx_signal"},
+  {:nx_signal, "~> 0.1"},
   {:vega_lite, "~> 0.1"},
   {:kino_vega_lite, "~> 0.1"}
 ])

--- a/guides/spectrogram.livemd
+++ b/guides/spectrogram.livemd
@@ -2,7 +2,7 @@
 
 ```elixir
 Mix.install([
-  {:nx_signal, ">= 0.0.0", github: "polvalente/nx-signal"},
+  {:nx_signal, "~> 0.1"},
   {:vega_lite, "~> 0.1.4"},
   {:kino_vega_lite, "~> 0.1.1"}
 ])


### PR DESCRIPTION
The version 0.5 was probably copy paste from the original nx repository. At the moment the published version is 0.1.

(I was making a livebook to fiddle around with nx_signal and noticed)