### PR TITLE
Fix vectorization for stft

### DIFF
--- a/lib/nx_signal.ex
+++ b/lib/nx_signal.ex
@@ -355,6 +355,8 @@ defmodule NxSignal do
     output = Nx.broadcast(Nx.tensor(0, type: tensor.type), output_shape)
     {num_windows, _} = Nx.shape(output)
 
+    [output, tensor] = Nx.broadcast_vectors([output, tensor])
+
     {output, _, _, _} =
       while {output, i = 0, current_window = 0, t = tensor}, current_window < num_windows do
         window = t |> Nx.slice([i], [window_length])


### PR DESCRIPTION
Currently vectorization results in an error:

```
** (CompileError) /Users/jonatanklosko/git/nx_signal/lib/nx_signal.ex:359: the do-block in while must return tensors with the same shape, type, and names as the initial arguments.

{
 <<<<< Body (do-block) <<<<<
 #Nx.Tensor<
   vectorized[batch: 1]
   f32[3001][400]
 >
 ==========
 #Nx.Tensor<
   f32[3001][400]
 >
 >>>>>     Initial     >>>>>
 , #Nx.Tensor<
   s64
 >, #Nx.Tensor<
   s64
 >, #Nx.Tensor<
   vectorized[batch: 1]
   f32[480400]
 >}
```

Is this something we should relax in Nx? cc @josevalim