### PR TITLE
feat: implement firwin

### DIFF
--- a/guides/filtering.livemd
+++ b/guides/filtering.livemd
@@ -38,7 +38,7 @@ slice = (signal_length - 3000)..(signal_length - 2750)
 plot_data = %{y: Nx.to_flat_list(data[[slice]]), x: Nx.to_flat_list(t[[slice]])}
 ```
 
-<!-- livebook:{"attrs":{"chart_title":"Signal sample","height":400,"layers":[{"chart_type":"line","color_field":null,"color_field_aggregate":null,"color_field_bin":false,"color_field_scale_scheme":null,"color_field_type":null,"data_variable":"plot_data","x_field":"x","x_field_aggregate":null,"x_field_bin":false,"x_field_scale_type":null,"x_field_type":"quantitative","y_field":"y","y_field_aggregate":null,"y_field_bin":false,"y_field_scale_type":null,"y_field_type":"quantitative"}],"vl_alias":"Elixir.VegaLite","width":600},"chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":"eyJjaGFydF90aXRsZSI6IlNpZ25hbCBzYW1wbGUiLCJoZWlnaHQiOjQwMCwibGF5ZXJzIjpbeyJhY3RpdmUiOnRydWUsImNoYXJ0X3R5cGUiOiJsaW5lIiwiY29sb3JfZmllbGQiOm51bGwsImNvbG9yX2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwiY29sb3JfZmllbGRfYmluIjpmYWxzZSwiY29sb3JfZmllbGRfc2NhbGVfc2NoZW1lIjpudWxsLCJjb2xvcl9maWVsZF90eXBlIjpudWxsLCJkYXRhX3ZhcmlhYmxlIjoicGxvdF9kYXRhIiwiZ2VvZGF0YV9jb2xvciI6ImJsdWUiLCJsYXRpdHVkZV9maWVsZCI6bnVsbCwibG9uZ2l0dWRlX2ZpZWxkIjpudWxsLCJ4X2ZpZWxkIjoieCIsInhfZmllbGRfYWdncmVnYXRlIjpudWxsLCJ4X2ZpZWxkX2JpbiI6ZmFsc2UsInhfZmllbGRfc2NhbGVfdHlwZSI6bnVsbCwieF9maWVsZF90eXBlIjoicXVhbnRpdGF0aXZlIiwieV9maWVsZCI6InkiLCJ5X2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwieV9maWVsZF9iaW4iOmZhbHNlLCJ5X2ZpZWxkX3NjYWxlX3R5cGUiOm51bGwsInlfZmllbGRfdHlwZSI6InF1YW50aXRhdGl2ZSJ9XSwidmxfYWxpYXMiOiJFbGl4aXIuVmVnYUxpdGUiLCJ3aWR0aCI6NjAwfQ","chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 VegaLite.new(width: 600, height: 400, title: "Signal sample")
@@ -51,18 +51,14 @@ VegaLite.new(width: 600, height: 400, title: "Signal sample")
 ## Preparing the Filter
 
 ```elixir
-# The filter used is a simple ideal filter specified through sinc
-
 # Cutoff frequency in Hz
 fc = 600
-filter_indices = Nx.iota({window_length}) |> Nx.subtract(div(window_length, 2))
 
-h_ideal =
-  Nx.multiply(2 * fc / fs, NxSignal.Filters.sinc(Nx.multiply(2 * fc / fs, filter_indices)))
+# Design the FIR filter coefficients using the window method
+h = NxSignal.Filters.firwin(window_length, fc, sampling_rate: fs, window: :hann)
 
-window = NxSignal.Windows.hann(n: window_length)
-
-h = Nx.multiply(h_ideal, window)
+# Separate periodic Hann window for STFT analysis
+stft_window = NxSignal.Windows.hann(window_length)
 
 hfft =
   h
@@ -94,7 +90,7 @@ plot_data = %{
 }
 ```
 
-<!-- livebook:{"attrs":{"chart_title":"600 Hz Low-Pass filter (Hann window); L = 2048","height":400,"layers":[{"chart_type":"line","color_field":null,"color_field_aggregate":null,"color_field_bin":false,"color_field_scale_scheme":null,"color_field_type":null,"data_variable":"plot_data","x_field":"n","x_field_aggregate":null,"x_field_bin":false,"x_field_scale_type":null,"x_field_type":"quantitative","y_field":"h","y_field_aggregate":null,"y_field_bin":false,"y_field_scale_type":null,"y_field_type":"quantitative"}],"vl_alias":"Elixir.VegaLite","width":600},"chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":"eyJjaGFydF90aXRsZSI6IjYwMCBIeiBMb3ctUGFzcyBmaWx0ZXIgKEhhbm4gd2luZG93KTsgTCA9IDIwNDgiLCJoZWlnaHQiOjQwMCwibGF5ZXJzIjpbeyJhY3RpdmUiOnRydWUsImNoYXJ0X3R5cGUiOiJsaW5lIiwiY29sb3JfZmllbGQiOm51bGwsImNvbG9yX2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwiY29sb3JfZmllbGRfYmluIjpmYWxzZSwiY29sb3JfZmllbGRfc2NhbGVfc2NoZW1lIjpudWxsLCJjb2xvcl9maWVsZF90eXBlIjpudWxsLCJkYXRhX3ZhcmlhYmxlIjoicGxvdF9kYXRhIiwiZ2VvZGF0YV9jb2xvciI6ImJsdWUiLCJsYXRpdHVkZV9maWVsZCI6bnVsbCwibG9uZ2l0dWRlX2ZpZWxkIjpudWxsLCJ4X2ZpZWxkIjoibiIsInhfZmllbGRfYWdncmVnYXRlIjpudWxsLCJ4X2ZpZWxkX2JpbiI6ZmFsc2UsInhfZmllbGRfc2NhbGVfdHlwZSI6bnVsbCwieF9maWVsZF90eXBlIjoicXVhbnRpdGF0aXZlIiwieV9maWVsZCI6ImgiLCJ5X2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwieV9maWVsZF9iaW4iOmZhbHNlLCJ5X2ZpZWxkX3NjYWxlX3R5cGUiOm51bGwsInlfZmllbGRfdHlwZSI6InF1YW50aXRhdGl2ZSJ9XSwidmxfYWxpYXMiOiJFbGl4aXIuVmVnYUxpdGUiLCJ3aWR0aCI6NjAwfQ","chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 VegaLite.new(
@@ -108,13 +104,13 @@ VegaLite.new(
 |> VegaLite.encode_field(:y, "h", type: :quantitative)
 ```
 
-<!-- livebook:{"attrs":{"chart_title":"FFT - 1200 Hz Low-Pass filter (Hann window); L = 1764","height":400,"layers":[{"chart_type":"line","color_field":null,"color_field_aggregate":null,"color_field_bin":false,"color_field_scale_scheme":null,"color_field_type":null,"data_variable":"plot_data","x_field":"f","x_field_aggregate":null,"x_field_bin":false,"x_field_scale_type":null,"x_field_type":"quantitative","y_field":"hfft","y_field_aggregate":null,"y_field_bin":false,"y_field_scale_type":null,"y_field_type":"quantitative"}],"vl_alias":"Elixir.VegaLite","width":600},"chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":"eyJjaGFydF90aXRsZSI6IkZGVCAtIDYwMCBIeiBMb3ctUGFzcyBmaWx0ZXIgKEhhbm4gd2luZG93KTsgTCA9IDIwNDgiLCJoZWlnaHQiOjQwMCwibGF5ZXJzIjpbeyJhY3RpdmUiOnRydWUsImNoYXJ0X3R5cGUiOiJsaW5lIiwiY29sb3JfZmllbGQiOm51bGwsImNvbG9yX2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwiY29sb3JfZmllbGRfYmluIjpmYWxzZSwiY29sb3JfZmllbGRfc2NhbGVfc2NoZW1lIjpudWxsLCJjb2xvcl9maWVsZF90eXBlIjpudWxsLCJkYXRhX3ZhcmlhYmxlIjoicGxvdF9kYXRhIiwiZ2VvZGF0YV9jb2xvciI6ImJsdWUiLCJsYXRpdHVkZV9maWVsZCI6bnVsbCwibG9uZ2l0dWRlX2ZpZWxkIjpudWxsLCJ4X2ZpZWxkIjoiZiIsInhfZmllbGRfYWdncmVnYXRlIjpudWxsLCJ4X2ZpZWxkX2JpbiI6ZmFsc2UsInhfZmllbGRfc2NhbGVfdHlwZSI6bnVsbCwieF9maWVsZF90eXBlIjoicXVhbnRpdGF0aXZlIiwieV9maWVsZCI6ImhmZnQiLCJ5X2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwieV9maWVsZF9iaW4iOmZhbHNlLCJ5X2ZpZWxkX3NjYWxlX3R5cGUiOm51bGwsInlfZmllbGRfdHlwZSI6InF1YW50aXRhdGl2ZSJ9XSwidmxfYWxpYXMiOiJFbGl4aXIuVmVnYUxpdGUiLCJ3aWR0aCI6NjAwfQ","chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 VegaLite.new(
   width: 600,
   height: 400,
-  title: "FFT - 1200 Hz Low-Pass filter (Hann window); L = 1764"
+  title: "FFT - 600 Hz Low-Pass filter (Hann window); L = 2048"
 )
 |> VegaLite.data_from_values(plot_data, only: ["f", "hfft"])
 |> VegaLite.mark(:line)
@@ -122,15 +118,24 @@ VegaLite.new(
 |> VegaLite.encode_field(:y, "hfft", type: :quantitative)
 ```
 
+## Direct Convolution
+
+The simplest way to apply the FIR filter is to convolve the signal directly with the coefficients in the time domain.
+
+```elixir
+data_filtered =
+  NxSignal.Convolution.convolve(data, h, mode: :same, method: :fft)
+  |> Nx.as_type(data.type)
+```
+
 ## Filtering the data
 
 ```elixir
-# Now that we have our filter, instead of convolving the filter
-# with the time representation of the signal, we can multiply each
-# STFT frame by the DFT of the filter (represented by hfft)
+# Alternatively, we can multiply each STFT frame by the DFT of the
+# filter (represented by hfft) to apply it in the frequency domain.
 
 {z, t, f} =
-  NxSignal.stft(data, window, fft_length: window_length, sampling_rate: fs, scaling: :spectrum)
+  NxSignal.stft(data, stft_window, fft_length: window_length, sampling_rate: fs, scaling: :spectrum)
 ```
 
 ```elixir
@@ -150,7 +155,7 @@ filtered_spectrogram =
 # Reconstruct the time signal
 data_out =
   z_filtered
-  |> NxSignal.istft(window, fft_length: window_length, scaling: :spectrum, sampling_rate: fs)
+  |> NxSignal.istft(stft_window, fft_length: window_length, scaling: :spectrum, sampling_rate: fs)
   |> Nx.as_type(data.type)
 ```
 
@@ -220,7 +225,7 @@ plot_data = %{
 }
 ```
 
-<!-- livebook:{"attrs":{"chart_title":"Reconstructed Signal","height":400,"layers":[{"chart_type":"line","color_field":null,"color_field_aggregate":null,"color_field_bin":false,"color_field_scale_scheme":null,"color_field_type":null,"data_variable":"plot_data","x_field":"x","x_field_aggregate":null,"x_field_bin":false,"x_field_scale_type":null,"x_field_type":"quantitative","y_field":"y","y_field_aggregate":null,"y_field_bin":false,"y_field_scale_type":null,"y_field_type":"quantitative"}],"vl_alias":"Elixir.VegaLite","width":600},"chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
+<!-- livebook:{"attrs":"eyJjaGFydF90aXRsZSI6IlJlY29uc3RydWN0ZWQgU2lnbmFsIiwiaGVpZ2h0Ijo0MDAsImxheWVycyI6W3siYWN0aXZlIjp0cnVlLCJjaGFydF90eXBlIjoibGluZSIsImNvbG9yX2ZpZWxkIjpudWxsLCJjb2xvcl9maWVsZF9hZ2dyZWdhdGUiOm51bGwsImNvbG9yX2ZpZWxkX2JpbiI6ZmFsc2UsImNvbG9yX2ZpZWxkX3NjYWxlX3NjaGVtZSI6bnVsbCwiY29sb3JfZmllbGRfdHlwZSI6bnVsbCwiZGF0YV92YXJpYWJsZSI6InBsb3RfZGF0YSIsImdlb2RhdGFfY29sb3IiOiJibHVlIiwibGF0aXR1ZGVfZmllbGQiOm51bGwsImxvbmdpdHVkZV9maWVsZCI6bnVsbCwieF9maWVsZCI6IngiLCJ4X2ZpZWxkX2FnZ3JlZ2F0ZSI6bnVsbCwieF9maWVsZF9iaW4iOmZhbHNlLCJ4X2ZpZWxkX3NjYWxlX3R5cGUiOm51bGwsInhfZmllbGRfdHlwZSI6InF1YW50aXRhdGl2ZSIsInlfZmllbGQiOiJ5IiwieV9maWVsZF9hZ2dyZWdhdGUiOm51bGwsInlfZmllbGRfYmluIjpmYWxzZSwieV9maWVsZF9zY2FsZV90eXBlIjpudWxsLCJ5X2ZpZWxkX3R5cGUiOiJxdWFudGl0YXRpdmUifV0sInZsX2FsaWFzIjoiRWxpeGlyLlZlZ2FMaXRlIiwid2lkdGgiOjYwMH0","chunks":null,"kind":"Elixir.KinoVegaLite.ChartCell","livebook_object":"smart_cell"} -->
 
 ```elixir
 VegaLite.new(width: 600, height: 400, title: "Reconstructed Signal")

--- a/lib/nx_signal/filters.ex
+++ b/lib/nx_signal/filters.ex
@@ -156,6 +156,7 @@ defmodule NxSignal.Filters do
 
     type = opts[:type]
     nyq = opts[:sampling_rate] / 2.0
+
     if not is_list(cutoff) do
       raise ArgumentError, "cutoff must be a list of frequencies, got: #{inspect(cutoff)}"
     end
@@ -228,8 +229,12 @@ defmodule NxSignal.Filters do
   deftransformp firwin_scale(h, alpha, cutoff_list, pass_zero) do
     scale_freq =
       cond do
-        pass_zero -> 0.0
-        match?([_], cutoff_list) -> 1.0
+        pass_zero ->
+          0.0
+
+        match?([_], cutoff_list) ->
+          1.0
+
         true ->
           [first, second | _] = cutoff_list
           (first + second) / 2.0

--- a/lib/nx_signal/filters.ex
+++ b/lib/nx_signal/filters.ex
@@ -120,8 +120,7 @@ defmodule NxSignal.Filters do
   ## Arguments
 
     * `num_taps` - number of filter coefficients (filter order + 1).
-    * `cutoff` - cutoff frequency or list of cutoff frequencies in the same
-      units as `sampling_rate`.
+    * `cutoff` - list of cutoff frequencies in the same units as `sampling_rate`.
 
   ## Options
 
@@ -139,7 +138,7 @@ defmodule NxSignal.Filters do
 
   ## Examples
 
-      iex> coeffs = NxSignal.Filters.firwin(5, 0.3, window: :hamming, sampling_rate: 2.0)
+      iex> coeffs = NxSignal.Filters.firwin(5, [0.3], window: :hamming, sampling_rate: 2.0)
       iex> Nx.shape(coeffs)
       {5}
 
@@ -157,23 +156,34 @@ defmodule NxSignal.Filters do
 
     type = opts[:type]
     nyq = opts[:sampling_rate] / 2.0
-    cutoff_list = cutoff |> List.wrap() |> Enum.map(&(&1 / nyq))
+    if not is_list(cutoff) do
+      raise ArgumentError, "cutoff must be a list of frequencies, got: #{inspect(cutoff)}"
+    end
 
-    # Validate cutoffs are strictly in (0, 1)
-    Enum.each(cutoff_list, fn fc ->
-      if fc <= 0.0 or fc >= 1.0 do
-        raise ArgumentError,
-              "cutoff must be strictly between 0 and Nyquist (exclusive), got: #{fc * nyq}"
-      end
-    end)
+    cutoff_list = cutoff |> Enum.map(&(&1 / nyq)) |> Enum.sort()
+
+    # Validate cutoffs are strictly in (0, 1) — after sorting, only the extremes need checking
+    first_cutoff = List.first(cutoff_list)
+    last_cutoff = List.last(cutoff_list)
+
+    if first_cutoff <= 0.0 do
+      raise ArgumentError,
+            "cutoff must be strictly between 0 and Nyquist (exclusive), got: #{first_cutoff * nyq}"
+    end
+
+    if last_cutoff >= 1.0 do
+      raise ArgumentError,
+            "cutoff must be strictly between 0 and Nyquist (exclusive), got: #{last_cutoff * nyq}"
+    end
 
     # Type II filters (even num_taps) have a zero at Nyquist.
     # Any filter requiring gain there must use an odd number of taps.
     n_cuts = length(cutoff_list)
+    even_n_cuts = rem(n_cuts, 2) == 0
 
     nyquist_gain =
-      (opts[:pass_zero] and rem(n_cuts, 2) == 0) or
-        (not opts[:pass_zero] and rem(n_cuts, 2) == 1)
+      (opts[:pass_zero] and even_n_cuts) or
+        (not opts[:pass_zero] and not even_n_cuts)
 
     if nyquist_gain and rem(num_taps, 2) == 0 do
       raise ArgumentError,
@@ -196,41 +206,44 @@ defmodule NxSignal.Filters do
         if opts[:pass_zero], do: rem(i, 2) == 0, else: rem(i, 2) == 1
       end)
       |> Enum.reduce(Nx.broadcast(Nx.tensor(0.0, type: type), {num_taps}), fn {[a, b], _i}, acc ->
-        contribution =
-          Nx.subtract(
-            Nx.multiply(b, NxSignal.Waveforms.sinc(Nx.multiply(b, alpha))),
-            Nx.multiply(a, NxSignal.Waveforms.sinc(Nx.multiply(a, alpha)))
-          )
-
-        Nx.add(acc, contribution)
+        firwin_contribution(a, b, alpha, acc)
       end)
 
     w = firwin_build_window(num_taps, opts[:window], type)
     h = Nx.multiply(h, w)
 
     if opts[:scale] do
-      scale_freq = firwin_scale_freq(cutoff_list, opts[:pass_zero])
-
-      scale_factor =
-        Nx.abs(
-          Nx.dot(
-            h,
-            Nx.cos(Nx.multiply(alpha, :math.pi() * scale_freq))
-          )
-        )
-
-      Nx.divide(h, scale_factor)
+      firwin_scale(h, alpha, cutoff_list, opts[:pass_zero])
     else
       h
     end
   end
 
-  deftransformp firwin_scale_freq(cutoff_list, pass_zero) do
-    cond do
-      pass_zero -> 0.0
-      length(cutoff_list) == 1 -> 1.0
-      true -> (List.first(cutoff_list) + Enum.at(cutoff_list, 1)) / 2.0
-    end
+  defnp firwin_contribution(a, b, alpha, acc) do
+    contribution_a = a * NxSignal.Waveforms.sinc(a * alpha)
+    contribution_b = b * NxSignal.Waveforms.sinc(b * alpha)
+    acc + contribution_b - contribution_a
+  end
+
+  deftransformp firwin_scale(h, alpha, cutoff_list, pass_zero) do
+    scale_freq =
+      cond do
+        pass_zero -> 0.0
+        match?([_], cutoff_list) -> 1.0
+        true ->
+          [first, second | _] = cutoff_list
+          (first + second) / 2.0
+      end
+
+    scale_factor =
+      Nx.abs(
+        Nx.dot(
+          h,
+          Nx.cos(Nx.multiply(alpha, :math.pi() * scale_freq))
+        )
+      )
+
+    Nx.divide(h, scale_factor)
   end
 
   deftransformp firwin_build_window(num_taps, window, type) do

--- a/lib/nx_signal/filters.ex
+++ b/lib/nx_signal/filters.ex
@@ -109,6 +109,157 @@ defmodule NxSignal.Filters do
     |> Nx.as_type(Nx.type(t))
   end
 
+  @doc """
+  FIR filter design using the window method.
+
+  Computes the coefficients of a finite impulse response (FIR) filter.
+  The filter has linear phase (Type I for odd `num_taps`, Type II for even).
+  Type II filters have a zero at Nyquist, so a filter requiring gain there
+  must use an odd number of taps.
+
+  ## Arguments
+
+    * `num_taps` - number of filter coefficients (filter order + 1).
+    * `cutoff` - cutoff frequency or list of cutoff frequencies in the same
+      units as `sampling_rate`.
+
+  ## Options
+
+    * `:window` - window function to apply. One of `:hamming`, `:hann`,
+      `:blackman`, `:bartlett`, `:rectangular`, or `{:kaiser, beta}`.
+      Defaults to `:hamming`.
+    * `:pass_zero` - if `true`, the DC gain is 1 (lowpass or bandstop);
+      if `false`, the DC gain is 0 (highpass or bandpass). Defaults to `true`.
+    * `:scale` - if `true`, normalise the coefficients so the frequency
+      response is exactly 1 at a reference frequency. Defaults to `true`.
+    * `:sampling_rate` - the sampling rate in Hz; `cutoff` is given in the
+      same units. Defaults to `2.0` so cutoffs are already normalised to
+      `[0, 1]` where `1` equals Nyquist.
+    * `:type` - output tensor type. Defaults to `{:f, 32}`.
+
+  ## Examples
+
+      iex> coeffs = NxSignal.Filters.firwin(5, 0.3, window: :hamming, sampling_rate: 2.0)
+      iex> Nx.shape(coeffs)
+      {5}
+
+  """
+  @doc type: :filters
+  deftransform firwin(num_taps, cutoff, opts \\ []) do
+    opts =
+      Keyword.validate!(opts,
+        window: :hamming,
+        pass_zero: true,
+        scale: true,
+        sampling_rate: 2.0,
+        type: {:f, 32}
+      )
+
+    type = opts[:type]
+    nyq = opts[:sampling_rate] / 2.0
+    cutoff_list = cutoff |> List.wrap() |> Enum.map(&(&1 / nyq))
+
+    # Validate cutoffs are strictly in (0, 1)
+    Enum.each(cutoff_list, fn fc ->
+      if fc <= 0.0 or fc >= 1.0 do
+        raise ArgumentError,
+              "cutoff must be strictly between 0 and Nyquist (exclusive), got: #{fc * nyq}"
+      end
+    end)
+
+    # Type II filters (even num_taps) have a zero at Nyquist.
+    # Any filter requiring gain there must use an odd number of taps.
+    n_cuts = length(cutoff_list)
+
+    nyquist_gain =
+      (opts[:pass_zero] and rem(n_cuts, 2) == 0) or
+        (not opts[:pass_zero] and rem(n_cuts, 2) == 1)
+
+    if nyquist_gain and rem(num_taps, 2) == 0 do
+      raise ArgumentError,
+            "a filter with non-zero gain at Nyquist (e.g. highpass) requires " <>
+              "an odd number of taps, got: #{num_taps}"
+    end
+
+    m = (num_taps - 1) / 2.0
+    alpha = Nx.subtract(Nx.iota({num_taps}, type: type), m)
+
+    # Build ideal impulse response by summing contributions from each passband.
+    # Passband pairs are selected at compile time from [0, c1, c2, ..., cn, 1].
+    all_freqs = [0.0 | cutoff_list] ++ [1.0]
+
+    h =
+      all_freqs
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.with_index()
+      |> Enum.filter(fn {_pair, i} ->
+        if opts[:pass_zero], do: rem(i, 2) == 0, else: rem(i, 2) == 1
+      end)
+      |> Enum.reduce(Nx.broadcast(Nx.tensor(0.0, type: type), {num_taps}), fn {[a, b], _i}, acc ->
+        contribution =
+          Nx.subtract(
+            Nx.multiply(b, NxSignal.Waveforms.sinc(Nx.multiply(b, alpha))),
+            Nx.multiply(a, NxSignal.Waveforms.sinc(Nx.multiply(a, alpha)))
+          )
+
+        Nx.add(acc, contribution)
+      end)
+
+    w = firwin_build_window(num_taps, opts[:window], type)
+    h = Nx.multiply(h, w)
+
+    if opts[:scale] do
+      scale_freq = firwin_scale_freq(cutoff_list, opts[:pass_zero])
+
+      scale_factor =
+        Nx.abs(
+          Nx.dot(
+            h,
+            Nx.cos(Nx.multiply(alpha, :math.pi() * scale_freq))
+          )
+        )
+
+      Nx.divide(h, scale_factor)
+    else
+      h
+    end
+  end
+
+  deftransformp firwin_scale_freq(cutoff_list, pass_zero) do
+    cond do
+      pass_zero -> 0.0
+      length(cutoff_list) == 1 -> 1.0
+      true -> (List.first(cutoff_list) + Enum.at(cutoff_list, 1)) / 2.0
+    end
+  end
+
+  deftransformp firwin_build_window(num_taps, window, type) do
+    case window do
+      :hamming ->
+        NxSignal.Windows.hamming(num_taps, is_periodic: false, type: type)
+
+      :hann ->
+        NxSignal.Windows.hann(num_taps, is_periodic: false, type: type)
+
+      :blackman ->
+        NxSignal.Windows.blackman(num_taps, is_periodic: false, type: type)
+
+      :bartlett ->
+        NxSignal.Windows.bartlett(num_taps, type: type)
+
+      :rectangular ->
+        NxSignal.Windows.rectangular(num_taps, type: type)
+
+      {:kaiser, beta} ->
+        NxSignal.Windows.kaiser(num_taps, beta: beta, is_periodic: false, type: type)
+
+      _ ->
+        raise ArgumentError,
+              "unknown window #{inspect(window)}, supported: " <>
+                ":hamming, :hann, :blackman, :bartlett, :rectangular, {:kaiser, beta}"
+    end
+  end
+
   defnp wiener_n(t, kernel, noise, opts) do
     size = opts[:size]
 

--- a/test/nx_signal/filters_test.exs
+++ b/test/nx_signal/filters_test.exs
@@ -255,7 +255,7 @@ defmodule NxSignal.FiltersTest do
           0.020103708268285354
         ])
 
-      assert_all_close(NxSignal.Filters.firwin(5, 0.3), expected, atol: 1.0e-5)
+      assert_all_close(NxSignal.Filters.firwin(5, [0.3]), expected, atol: 1.0e-5)
     end
 
     test "highpass with hamming window" do
@@ -271,7 +271,7 @@ defmodule NxSignal.FiltersTest do
         ])
 
       assert_all_close(
-        NxSignal.Filters.firwin(7, 0.4, pass_zero: false),
+        NxSignal.Filters.firwin(7, [0.4], pass_zero: false),
         expected,
         atol: 1.0e-5
       )
@@ -334,7 +334,7 @@ defmodule NxSignal.FiltersTest do
         ])
 
       assert_all_close(
-        NxSignal.Filters.firwin(7, 0.5, window: {:kaiser, 5.0}),
+        NxSignal.Filters.firwin(7, [0.5], window: {:kaiser, 5.0}),
         expected,
         atol: 1.0e-3
       )
@@ -353,7 +353,7 @@ defmodule NxSignal.FiltersTest do
         ])
 
       assert_all_close(
-        NxSignal.Filters.firwin(7, 0.4, window: :rectangular),
+        NxSignal.Filters.firwin(7, [0.4], window: :rectangular),
         expected,
         atol: 1.0e-5
       )
@@ -370,7 +370,7 @@ defmodule NxSignal.FiltersTest do
         ])
 
       assert_all_close(
-        NxSignal.Filters.firwin(5, 0.3, scale: false),
+        NxSignal.Filters.firwin(5, [0.3], scale: false),
         expected,
         atol: 1.0e-5
       )
@@ -387,7 +387,7 @@ defmodule NxSignal.FiltersTest do
         ])
 
       assert_all_close(
-        NxSignal.Filters.firwin(5, 1000, sampling_rate: 8000),
+        NxSignal.Filters.firwin(5, [1000], sampling_rate: 8000),
         expected,
         atol: 1.0e-5
       )
@@ -395,23 +395,23 @@ defmodule NxSignal.FiltersTest do
 
     test "raises when cutoff is at or above Nyquist" do
       assert_raise ArgumentError, ~r/cutoff must be strictly between 0 and Nyquist/, fn ->
-        NxSignal.Filters.firwin(5, 1.0)
+        NxSignal.Filters.firwin(5, [1.0])
       end
 
       assert_raise ArgumentError, ~r/cutoff must be strictly between 0 and Nyquist/, fn ->
-        NxSignal.Filters.firwin(5, 0.0)
+        NxSignal.Filters.firwin(5, [0.0])
       end
     end
 
     test "raises when even num_taps would produce gain at Nyquist" do
       assert_raise ArgumentError, ~r/odd number of taps/, fn ->
-        NxSignal.Filters.firwin(6, 0.4, pass_zero: false)
+        NxSignal.Filters.firwin(6, [0.4], pass_zero: false)
       end
     end
 
     test "raises for unknown window" do
       assert_raise ArgumentError, ~r/unknown window/, fn ->
-        NxSignal.Filters.firwin(5, 0.3, window: :bogus)
+        NxSignal.Filters.firwin(5, [0.3], window: :bogus)
       end
     end
   end

--- a/test/nx_signal/filters_test.exs
+++ b/test/nx_signal/filters_test.exs
@@ -241,4 +241,178 @@ defmodule NxSignal.FiltersTest do
                )
     end
   end
+
+  describe "firwin/3" do
+    # Reference values generated with scipy.signal.firwin
+
+    test "lowpass with default hamming window" do
+      expected =
+        Nx.tensor([
+          0.020103708268285354,
+          0.23086668180542194,
+          0.4980592198525855,
+          0.23086668180542194,
+          0.020103708268285354
+        ])
+
+      assert_all_close(NxSignal.Filters.firwin(5, 0.3), expected, atol: 1.0e-5)
+    end
+
+    test "highpass with hamming window" do
+      expected =
+        Nx.tensor([
+          0.004998140998601554,
+          -0.02905169455437149,
+          -0.23351680322070983,
+          0.6010660646645265,
+          -0.2335168032207099,
+          -0.02905169455437152,
+          0.004998140998601554
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(7, 0.4, pass_zero: false),
+        expected,
+        atol: 1.0e-5
+      )
+    end
+
+    test "bandpass with hann window" do
+      expected =
+        Nx.tensor([
+          0.0,
+          -0.034265228115753485,
+          -0.17548320982592003,
+          0.14143709641554006,
+          0.5732069654682745,
+          0.14143709641554006,
+          -0.17548320982592003,
+          -0.034265228115753485,
+          0.0
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(9, [0.2, 0.6], pass_zero: false, window: :hann),
+        expected,
+        atol: 1.0e-5
+      )
+    end
+
+    test "bandstop with blackman window" do
+      expected =
+        Nx.tensor([
+          0.0,
+          -0.004174601858029537,
+          0.0,
+          0.17126025417159732,
+          0.0,
+          0.6658286953728643,
+          0.0,
+          0.17126025417159732,
+          0.0,
+          -0.004174601858029537,
+          0.0
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(11, [0.3, 0.7], window: :blackman),
+        expected,
+        atol: 1.0e-5
+      )
+    end
+
+    test "lowpass with kaiser window" do
+      expected =
+        Nx.tensor([
+          -0.003951274147023466,
+          0.0,
+          0.25034887446528337,
+          0.5072047993634803,
+          0.25034887446528337,
+          0.0,
+          -0.003951274147023466
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(7, 0.5, window: {:kaiser, 5.0}),
+        expected,
+        atol: 1.0e-3
+      )
+    end
+
+    test "lowpass with rectangular window" do
+      expected =
+        Nx.tensor([
+          -0.058404528708691714,
+          0.08760679306303756,
+          0.28350153764274655,
+          0.37459239600581506,
+          0.28350153764274655,
+          0.08760679306303756,
+          -0.058404528708691714
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(7, 0.4, window: :rectangular),
+        expected,
+        atol: 1.0e-5
+      )
+    end
+
+    test "scale: false returns unscaled coefficients" do
+      expected =
+        Nx.tensor([
+          0.012109227658250522,
+          0.13905977799613067,
+          0.3,
+          0.13905977799613067,
+          0.012109227658250522
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(5, 0.3, scale: false),
+        expected,
+        atol: 1.0e-5
+      )
+    end
+
+    test "cutoff normalised by sampling_rate" do
+      expected =
+        Nx.tensor([
+          0.024553834015016568,
+          0.23438946423798604,
+          0.48211340349399473,
+          0.23438946423798604,
+          0.024553834015016568
+        ])
+
+      assert_all_close(
+        NxSignal.Filters.firwin(5, 1000, sampling_rate: 8000),
+        expected,
+        atol: 1.0e-5
+      )
+    end
+
+    test "raises when cutoff is at or above Nyquist" do
+      assert_raise ArgumentError, ~r/cutoff must be strictly between 0 and Nyquist/, fn ->
+        NxSignal.Filters.firwin(5, 1.0)
+      end
+
+      assert_raise ArgumentError, ~r/cutoff must be strictly between 0 and Nyquist/, fn ->
+        NxSignal.Filters.firwin(5, 0.0)
+      end
+    end
+
+    test "raises when even num_taps would produce gain at Nyquist" do
+      assert_raise ArgumentError, ~r/odd number of taps/, fn ->
+        NxSignal.Filters.firwin(6, 0.4, pass_zero: false)
+      end
+    end
+
+    test "raises for unknown window" do
+      assert_raise ArgumentError, ~r/unknown window/, fn ->
+        NxSignal.Filters.firwin(5, 0.3, window: :bogus)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements `NxSignal.Filters.firwin/3`, which makes FIR filter design possible using nx_signal's existing resources. Given a tap count, one or more cutoff frequencies, and a window name, it returns a vector of FIR filter coefficients that can then be applied to a signal with `NxSignal.Convolution.convolve/3`.

```elixir
# Design a 63-tap lowpass at 1 kHz, sampling rate 44.1 kHz
h = NxSignal.Filters.firwin(63, 1000, sampling_rate: 44_100, window: :hamming)

# Apply it
filtered = NxSignal.Convolution.convolve(signal, h, mode: :same)
```

`firwin` lives in `NxSignal.Filters` as a `deftransform`. Because the number of cutoff frequencies is a compile-time constant (a literal list), the passband enumeration (`Enum.chunk_every`, `Enum.filter`, `Enum.reduce`) runs at JIT-compile time and emits a statically-unrolled Nx expression graph.

Reference coefficients for testing were generated with [`scipy.signal.firwin`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.firwin.html) (SciPy 1.x, float64) and hard-coded in the test file. Tests use `assert_all_close` with `atol: 1.0e-5` to account for the f32 vs f64 arithmetic difference. The Kaiser window tests use a looser `atol: 1.0e-3` because `NxSignal.Windows.kaiser` uses a polynomial/asymptotic Bessel function approximation for $I_0$ rather than the Chebyshev series used by NumPy/SciPy, which introduces slightly larger errors for small arguments. This is a known divergence introduced in [#27](https://github.com/elixir-nx/nx_signal/pull/27).

### Possible follow-up: `guides/filtering.livemd`

I noticed that there are a couple of bugs in the existing filtering Livebook due to structural changes. Also, the introduction of this filter design method could simplify some of the manual setup in that file if accepted.

- Line 61 of the current guide calls `NxSignal.Filters.sinc/1`, which does not exist. The sinc function now lives in `NxSignal.Waveforms`.

- Line 63 calls `NxSignal.Windows.hann(n: window_length)`. After the window API was refactored to take a mandatory positional integer argument, this passes a keyword list as the first argument, which fails the `when is_integer(n)` guard:

```
** (FunctionClauseError) no function clause matching in NxSignal.Windows.hann/2
```

The correct call is `NxSignal.Windows.hann(window_length)` I think.

- The smart cell on line 111 is titled `"FFT - 1200 Hz Low-Pass filter (Hann window); L = 1764"`. However, the filter in the notebook is 600 Hz with `window_length = 2048` taps. This is probably a copy-paste artefact from an earlier version of the guide.

In terms of changes introduced here, the entire "Preparing the Filter" section currently does manually what `firwin` now encapsulates:

```elixir
fc = 600
filter_indices = Nx.iota({window_length}) |> Nx.subtract(div(window_length, 2))
h_ideal =
  Nx.multiply(2 * fc / fs, NxSignal.Filters.sinc(Nx.multiply(2 * fc / fs, filter_indices)))
window = NxSignal.Windows.hann(n: window_length)   # also broken
h = Nx.multiply(h_ideal, window)
```

So it could be simplified thus: 

```elixir
h = NxSignal.Filters.firwin(window_length, fc, sampling_rate: fs, window: :hann)
```

The `window` variable in the guide is currently serving double duty: it is used for both the FIR filter design and as the STFT analysis window passed to `NxSignal.stft/3` and `NxSignal.istft/3`. After the simplification, these two concerns would be separated:

```elixir
# FIR coefficients — symmetric window applied internally by firwin
h = NxSignal.Filters.firwin(window_length, fc, sampling_rate: fs, window: :hann)

# Separate periodic Hann window for STFT analysis
stft_window = NxSignal.Windows.hann(window_length)
```

`stft_window` would then replace every occurrence of `window` in the `stft` and `istft` calls. scipy also has separate concepts for a filter design window (symmetric, used once to shape the FIR coefficients) and an analysis window (periodic, used repeatedly in STFT frames) - [`firwin` defaults to symmetric](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.firwin.html) and [`stft` to `window='hann_periodic'`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.stft.html).

It would perhaps also be appropriate to add a short "Direct convolution" subsection before the existing STFT-based filtering section, demonstrating the simplest end-to-end usage of `firwin`:

```elixir
h = NxSignal.Filters.firwin(window_length, fc, sampling_rate: fs, window: :hann)

data_filtered =
  NxSignal.Convolution.convolve(data, h, mode: :same, method: :fft)
  |> Nx.as_type(data.type)
```

[Proposed changes (this is all working nicely locally using my local version of nx_signal in the deps)](https://gist.github.com/thomaspmurphy/8631b40c7684fe3b0d3e7b45631e517f)

I would be happy to add a PR addressing these. I am quite new to Elixir apologies if my code is not idiomatic—happy to work to improve it!